### PR TITLE
Add board parsing string to 2D list logic 

### DIFF
--- a/checkmate.py
+++ b/checkmate.py
@@ -1,3 +1,15 @@
 def checkmate(board: str):
-    # temporary placeholder
-    print("Fail")
+    parsed = parse_board(board)
+    return parsed
+
+
+def parse_board(board_str: str) -> list | None:
+    if not isinstance(board_str, str):
+        return None
+
+    rows = board_str.splitlines()
+    rows = [row for row in rows if row.strip() != ""]  # Remove empty lines
+
+    # 2D list
+    board = [list(row) for row in rows]
+    return board

--- a/main.py
+++ b/main.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 from checkmate import checkmate
 
-
-def main():
-    board = """\
+example_1 = """\
 R...
 .K..
 ..P.
-....
+....\
 """
+example_2 = """\
+..
+.K\
+"""
+
+
+def main():
+    board = example_1
     checkmate(board)
 
 


### PR DESCRIPTION
This pull request refactors the `checkmate.py` logic to introduce board parsing functionality and updates `main.py` to use example board strings and call the refactored code. The main focus is on improving how chess boards are represented and parsed for further processing.

**Refactoring and parsing improvements:**

* Added a new `parse_board` function in `checkmate.py` to convert a board string into a 2D list, handling empty lines and input validation. The `checkmate` function now uses this parser and returns the parsed board instead of printing a placeholder.

**Example data and usage updates:**

* Updated `main.py` to define two example board strings (`example_1` and `example_2`), and modified the `main` function to use `example_1` as input for the `checkmate` function.

**Resolves #2**